### PR TITLE
Corrected easing function in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ slideToggle({element: box})
 
 slideUp({element: box, slideSpeed: 1200})
 
-slideDown({element: box, slideSpeed: 800, easing: 'easeInOut'})
+slideDown({element: box, slideSpeed: 800, easing: 'ease-in-out'})
 
 // Promises (or async/await)
 slideDown({element: box, slideSpeed: 500}).then(() => {


### PR DESCRIPTION
**Description:**

This pull request addresses a minor typo in the README example. The `easing` option in the `slideDown` function was incorrectly using `easeInOut`. The correct CSS keyword for this easing function is `ease-in-out`.

This change ensures the example aligns with standard CSS easing function syntax, as documented on MDN: [https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function](https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function)

**Changes Made:**

* Updated the `slideDown` example in the README to use `ease-in-out` instead of `easeInOut`.

**Example (Before):**

```javascript
slideDown({element: box, slideSpeed: 800, easing: 'easeInOut'})